### PR TITLE
Clarify instructions for archive creation

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,9 @@ First enable developer mode on your Roku device:
 
 http://sdkdocs.roku.com/display/sdkdoc/Developer+Guide
 
-Then, zip up the source code directory. Visit 192.168.1.100 in your browser, updating the IP address with the IP of the Roku device. From here you can upload the zip to the device.
+Git clone this project.
+Zip up the contents of the main project directory(Eg: jellyfin-roku) such that the manifest is at the root of the archive.
+Visit 192.168.1.100 in your browser, updating the IP address with the IP of the Roku device. From here, you can upload the zip to the device.
 
 To debug, use any telnet client on port 8085 of the Roku. In windows, open a command promt:
 


### PR DESCRIPTION
Readme instructions were vague and could be interpreted several ways. Have added more precise wording that assist future users/developers.